### PR TITLE
Composer.json: typo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "timwhitlock/jparser",
     "description": "A JavaScript parsing library for PHP",
-    "licencse": "MIT",
+    "license": "MIT",
     "authors": [
         {
             "name": "Tim Whitlock",


### PR DESCRIPTION
The incorrect string "licencse" is not recognized on packagist.